### PR TITLE
Fix trailing spaces in Temporal Dates day_name field

### DIFF
--- a/temporal/temporal_core/doctype/temporal_manager/rebuild_dates_table.sql
+++ b/temporal/temporal_core/doctype/temporal_manager/rebuild_dates_table.sql
@@ -34,7 +34,7 @@ SELECT
 	NULL AS				"_assign",
 	NULL AS				"_liked_by",
 	calendar_date,
-	TO_CHAR(calendar_date, 'Day')		AS day_name,
+	TRIM(TO_CHAR(calendar_date, 'Day'))		AS day_name,
 	ROW_NUMBER() OVER (ORDER BY calendar_date)	AS scalar_value
 FROM
 	DateSequence


### PR DESCRIPTION
## Summary

- PostgreSQL's `TO_CHAR(date, 'Day')` right-pads day names to 9 chars (length of "Wednesday"), causing trailing spaces in `day_name` for all days except Wednesday
- Wrap with `TRIM()` to produce clean day names
- Fixes 625/730 rows in `tabTemporal Dates` that had trailing spaces, which could break joins with `tabDelivery Day`

## Test plan

- [ ] Deploy to staging and run "Rebuild Temporal Dates" from Temporal Manager
- [ ] Verify `SELECT DISTINCT day_name, LENGTH(day_name) FROM "tabTemporal Dates"` shows no padding
- [ ] Verify delivery date lookups (joins with `tabDelivery Day`) work correctly

Closes Farm-To-People/app_ftp#797

🤖 Generated with [Claude Code](https://claude.com/claude-code)